### PR TITLE
Develop dns mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ Functionality changes and additions
 * Add fail2ban jails for both above mentioned geoipblocking filters
 * Add fail2ban filters for web scanners and badbots
 * Add xapian full text searching to dovecot (from https://github.com/grosjo/fts-xapian)
-* Add rkhunter and chkrootkit 
-* Configure domain names for which only www will be hosted. Edit /etc/miabwwwdomains.conf to configure. DNS entries are not handled by this box!
+* Add rkhunter and chkrootkit
+  chkrootkit support is a bit dodgy, creating false positives every now and then, notably on kernel update.
+* Configure domain names for which only www will be hosted.
+  Edit /etc/miabwwwdomains.conf to configure. The box will handle incoming traffic asking for these domain names. The DNS entries are entered in an external DNS provider! If you want this box to handle the DNS entries, simply add a mail alias. (existing functionality of the vanilla Mail-in-a-Box)
 * Add some munin plugins
 * Update nextcloud to 20.0.8
 * Update roundcube carddav plugin to 4.1.1
 * Use shorter TTL values in the DNS server.
   To be used before moving e.g. DNS provider. Shortening TTL values will propagate changes faster. For reference, default TTL is 1 day, short TTL is 5 minutes. To use, edit file /etc/forceshortdnsttl and add a line for each domain for which shorter TTLs should be used. To use short TTLs for all known domains, add "forceshortdnsttl"
 * Use the box as a Hidden Master in the DNS system
-  Thus only the secondary DNS servers are used as public DNS servers. To use, edit file /etc/usehiddenmasterdns and add a line for each domain for which Hidden Master should be used. To use Hidden Master for all known domains, add "usehiddenmasterdns". At least two secondary servers should be set in the Custom DNS administration page.
+  Thus only the secondary DNS servers are used as public DNS servers. When using a hidden master, no glue records are necessary at your domain hoster. To use, edit file /etc/usehiddenmasterdns and add a line for each domain for which Hidden Master should be used. To use Hidden Master for all known domains, add "usehiddenmasterdns". At least two secondary servers should be set in the Custom DNS administration page.
 
 Bug fixes
 * Munin routes are ignored for Multi Factor Authentication [see github issue](https://github.com/mail-in-a-box/mailinabox/issues/1865)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ Functionality changes and additions
 * Add fail2ban filters for web scanners and badbots
 * Add xapian full text searching to dovecot (from https://github.com/grosjo/fts-xapian)
 * Add rkhunter and chkrootkit 
-* Configure domain names for which only www will be hosted. Edit /etc/miabwwwdomains.conf to configure.
+* Configure domain names for which only www will be hosted. Edit /etc/miabwwwdomains.conf to configure. DNS entries are not handled by this box!
 * Add some munin plugins
 * Update nextcloud to 20.0.8
 * Update roundcube carddav plugin to 4.1.1
+* Use shorter TTL values in the DNS server.
+  To be used before moving e.g. DNS provider. Shortening TTL values will propagate changes faster. For reference, default TTL is 1 day, short TTL is 5 minutes. To use, edit file /etc/forceshortdnsttl and add a line for each domain for which shorter TTLs should be used. To use short TTLs for all known domains, add "forceshortdnsttl"
+* Use the box as a Hidden Master in the DNS system
+  Thus only the secondary DNS servers are used as public DNS servers. To use, edit file /etc/usehiddenmasterdns and add a line for each domain for which Hidden Master should be used. To use Hidden Master for all known domains, add "usehiddenmasterdns". At least two secondary servers should be set in the Custom DNS administration page.
 
 Bug fixes
 * Munin routes are ignored for Multi Factor Authentication [see github issue](https://github.com/mail-in-a-box/mailinabox/issues/1865)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Functionality changes and additions
 * Update nextcloud to 20.0.8
 * Update roundcube carddav plugin to 4.1.1
 * Use shorter TTL values in the DNS server.
-  To be used before moving e.g. DNS provider. Shortening TTL values will propagate changes faster. For reference, default TTL is 1 day, short TTL is 5 minutes. To use, edit file /etc/forceshortdnsttl and add a line for each domain for which shorter TTLs should be used. To use short TTLs for all known domains, add "forceshortdnsttl"
+  To be used before for example when changing IP addresses. Shortening TTL values will propagate changes faster. For reference, default TTL is 1 day, short TTL is 5 minutes. To use, edit file /etc/forceshortdnsttl and add a line for each domain for which shorter TTLs should be used. To use short TTLs for all known domains, add "forceshortdnsttl"
 * Use the box as a Hidden Master in the DNS system
-  Thus only the secondary DNS servers are used as public DNS servers. When using a hidden master, no glue records are necessary at your domain hoster. To use, edit file /etc/usehiddenmasterdns and add a line for each domain for which Hidden Master should be used. To use Hidden Master for all known domains, add "usehiddenmasterdns". At least two secondary servers should be set in the Custom DNS administration page.
+  Thus only the secondary DNS servers are used as public DNS servers. When using a hidden master, no glue records are necessary at your domain hoster. To use, first setup secondary DNS servers via the Custom DNS administration page. At least two secondary servers should be set. When that functions, edit file /etc/usehiddenmasterdns and add a line for each domain for which Hidden Master should be used. To use Hidden Master for all known domains, add "usehiddenmasterdns".
 
 Bug fixes
 * Munin routes are ignored for Multi Factor Authentication [see github issue](https://github.com/mail-in-a-box/mailinabox/issues/1865)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
     export PUBLIC_IP=auto
     export PUBLIC_IPV6=auto
     export PRIMARY_HOSTNAME=auto
-    #export SKIP_NETWORK_CHECKS=1
+    export SKIP_NETWORK_CHECKS=1
 
     # Start the setup script.
     cd /vagrant

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -150,12 +150,12 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 		secondary_ns_list = get_secondary_dns(additional_records, mode="NS") 
 		
 		# Need at least two nameservers in the secondary dns list
-		useHiddenMaster = false
+		useHiddenMaster = False
 		if os.path.exists("/etc/usehiddenmasterdns") and len(secondary_ns_list) > 1:
 			with open("/etc/usehiddenmasterdns") as f:
 				for line in f:
 					if line == domain or line == "usehiddenmasterdns":
-						useHiddenMaster = true
+						useHiddenMaster = True
 						break
 		
 		if not useHiddenMaster:

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -503,22 +503,23 @@ $TTL {defttl}          ; default time to live
 """
 
 	# Default ttl values
-	p_defttl = 86400
-	p_refresh = 7200
-	p_retry = 1800
-	p_expire = 1209600
-	p_negttl = 86400
+	p_defttl = "1d"
+	p_refresh = "2h"
+	p_retry = "15m"
+	p_expire = "14d"
+	p_negttl = "12h"
 
 	primary_dns = "ns1" + env["PRIMARY_HOSTNAME"]
 
-	# Shorten dns ttl if file exists. Use just before moving domains, changin secondary dns servers etc
+	# Shorten dns ttl if file exists. Use before moving domains, changing secondary dns servers etc
 	if os.path.exists("/etc/forceshortdnsttl"):
-		p_defttl = 300
-		p_refresh = 3600
-		p_retry = 900
-		p_expire = 43200
-		p_negttl = 300
+		p_defttl = "5m"
+		p_refresh = "30m"
+		p_retry = "5m"
+		p_expire = "1d"
+		p_negttl = "5m"
 	
+	additional_records = list(get_custom_dns_config(env))
 	secondary_ns_list = get_secondary_dns(additional_records, mode="NS")
 	useHiddenMaster = os.path.exists("/etc/usehiddenmasterdns") and len(secondary_ns_list) > 1
 	

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -154,7 +154,7 @@ def build_zone(domain, all_domains, additional_records, www_redirect_domains, en
 		if os.path.exists("/etc/usehiddenmasterdns") and len(secondary_ns_list) > 1:
 			with open("/etc/usehiddenmasterdns") as f:
 				for line in f:
-					if line == domain or line == "usehiddenmasterdns":
+					if line.strip() == domain or line.strip() == "usehiddenmasterdns":
 						useHiddenMaster = True
 						break
 		
@@ -518,7 +518,7 @@ $TTL {defttl}          ; default time to live
 	if os.path.exists("/etc/forceshortdnsttl"):
 		with open("/etc/forceshortdnsttl") as f:
 			for line in f:
-				if line == domain or line == "forceshortdnsttl":
+				if line.strip() == domain or line.strip() == "forceshortdnsttl":
 					# Override the ttl values
 					p_defttl = "5m"
 					p_refresh = "30m"
@@ -537,7 +537,7 @@ $TTL {defttl}          ; default time to live
 	if os.path.exists("/etc/usehiddenmasterdns") and len(secondary_ns_list) > 1:
 		with open("/etc/usehiddenmasterdns") as f:
 			for line in f:
-				if line == domain or line == "usehiddenmasterdns":
+				if line.strip() == domain or line.strip() == "usehiddenmasterdns":
 					primary_dns = secondary_ns_list[0]
 					break
 	

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -509,7 +509,7 @@ $TTL {defttl}          ; default time to live
 	p_expire = "14d"
 	p_negttl = "12h"
 
-	primary_dns = "ns1" + env["PRIMARY_HOSTNAME"]
+	primary_dns = "ns1." + env["PRIMARY_HOSTNAME"]
 
 	# Shorten dns ttl if file exists. Use before moving domains, changing secondary dns servers etc
 	if os.path.exists("/etc/forceshortdnsttl"):

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -507,10 +507,10 @@ $TTL {defttl}          ; default time to live
 		   )
 """
 
-	# Default ttl values
+	# Default ttl values, following recomendations from zonemaster.iis.se
 	p_defttl = "1d"
-	p_refresh = "2h"
-	p_retry = "15m"
+	p_refresh = "4h"
+	p_retry = "1h"
 	p_expire = "14d"
 	p_negttl = "12h"
 

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -503,7 +503,17 @@ def check_dns_zone(domain, env, output, dns_zonefiles):
 	secondary_ns = custom_secondary_ns or ["ns2." + env['PRIMARY_HOSTNAME']]
 
 	existing_ns = query_dns(domain, "NS")
+
 	correct_ns = "; ".join(sorted(["ns1." + env['PRIMARY_HOSTNAME']] + secondary_ns))
+	
+	# Take hidden master dns into account, the mail-in-a-box is not known as nameserver in that case
+	if os.path.exists("/etc/usehiddenmasterdns") and len(secondary_ns) > 1:
+		with open("/etc/usehiddenmasterdns") as f:
+			for line in f:
+				if line.strip() == domain or line.strip() == "usehiddenmasterdns":
+					correct_ns = "; ".join(sorted(secondary_ns))
+					break
+	
 	ip = query_dns(domain, "A")
 
 	probably_external_dns = False


### PR DESCRIPTION
Develop several DNS modifications
- Configurable option to use short TTLs, e.g. default TTL is 5 minutes instead of 1 day
- Hidden Master on top of secondary nameservers
Both options configurable per domain (dns zone) hosted by the box